### PR TITLE
Fix GCHandle leak in OSX SafeDeleteSslContext

### DIFF
--- a/src/libraries/Common/src/Interop/OSX/System.Security.Cryptography.Native.Apple/Interop.Ssl.cs
+++ b/src/libraries/Common/src/Interop/OSX/System.Security.Cryptography.Native.Apple/Interop.Ssl.cs
@@ -460,6 +460,13 @@ namespace System.Net
 {
     internal sealed class SafeSslHandle : SafeHandle
     {
+        // Backreference used by AppleCryptoNative_SslSetConnection so native
+        // Read/Write callbacks can resolve the owning SafeDeleteSslContext.
+        // Owned here so the lifetime is tied to ReleaseHandle, which only
+        // runs once all outstanding P/Invokes (and therefore any in-flight
+        // callbacks) have completed.
+        private GCHandle _connectionGCHandle;
+
         public SafeSslHandle()
             : base(IntPtr.Zero, ownsHandle: true)
         {
@@ -470,10 +477,21 @@ namespace System.Net
         {
         }
 
+        internal void SetConnectionGCHandle(GCHandle handle)
+        {
+            Debug.Assert(!_connectionGCHandle.IsAllocated, "Connection GCHandle already set");
+            _connectionGCHandle = handle;
+        }
+
         protected override bool ReleaseHandle()
         {
             Interop.CoreFoundation.CFRelease(handle);
             SetHandle(IntPtr.Zero);
+            if (_connectionGCHandle.IsAllocated)
+            {
+                _connectionGCHandle.Free();
+            }
+
             return true;
         }
 

--- a/src/libraries/System.Net.Security/src/System/Net/Security/Pal.OSX/SafeDeleteSslContext.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/Pal.OSX/SafeDeleteSslContext.cs
@@ -191,7 +191,13 @@ namespace System.Net
 
         private void SslSetConnection(SafeSslHandle sslContext)
         {
+            // The GCHandle is owned by the SafeSslHandle and freed in its
+            // ReleaseHandle override, which only runs after all outstanding
+            // P/Invokes (and therefore any in-flight Read/Write callbacks)
+            // have completed. Freeing it here in Dispose would race with
+            // callbacks that are still in flight on another thread.
             GCHandle handle = GCHandle.Alloc(this, GCHandleType.Weak);
+            sslContext.SetConnectionGCHandle(handle);
 
             Interop.AppleCrypto.SslSetConnection(sslContext, GCHandle.ToIntPtr(handle));
         }


### PR DESCRIPTION
> [!NOTE]
> This PR was authored with help from GitHub Copilot.

`SafeDeleteSslContext.SslSetConnection` allocates a `GCHandle` so the native SecureTransport `Read`/`Write` callbacks can resolve back to the owning managed instance via the `IntPtr` passed to `SslSetConnection`. The handle was stored only in a local variable and never freed, so every SSL context created on the legacy macOS SecureTransport path leaked one GCHandle table slot for the lifetime of the process.

## Approach

The natural place to free the handle is in `SafeDeleteSslContext.Dispose`, but that races with in-flight native callbacks: `_sslContext.Dispose()` decrements the `SafeHandle` ref count but does not actually tear down the native context (and therefore stop callbacks) while another thread is still inside an `SslHandshake`/`SslRead`/`SslWrite` P/Invoke. Freeing the GCHandle immediately in `Dispose` reliably trips `Debug.Assert(context != null)` in `WriteToConnection`/`ReadFromConnection` when the SNI/handshake-failure paths tear the stream down concurrently with the native callback (confirmed locally by an assertion crash in `SslStreamSniTest.SslStream_ServerCallbackAndLocalCertificateSelectionSet_Throws`).

Instead, ownership of the GCHandle is moved into `SafeSslHandle` itself and freed from its `ReleaseHandle` override. `ReleaseHandle` only runs once the `SafeHandle` reference count reaches zero, which is also the moment `CFRelease` tears down the native `SSLContext` and after which no further callbacks can fire. That makes it the earliest race-free point to drop the backreference.

The GCHandle remains `Weak` to preserve existing GC behavior for the `SafeDeleteSslContext` instance; only the GCHandle table slot itself is reclaimed.

## Validation

- `dotnet build` of `System.Net.Security` succeeds with 0 warnings.
- `System.Net.Security.Unit.Tests`: 124 passed, 0 failed (osx-arm64, Debug).
- `System.Net.Security.Tests` (functional): 4964 passed, 0 failed, 18 skipped (osx-arm64, Debug). This includes `SslStreamSniTest.SslStream_ServerCallbackAndLocalCertificateSelectionSet_Throws`, which crashes with an alternative "free in Dispose" implementation and passes cleanly with this approach.

Note: this only affects the legacy SecureTransport path (`SafeDeleteSslContext`). The newer Network Framework path (`SafeDeleteNwContext`) already manages its GCHandle correctly via `_thisHandle.Free()` in its own dispose.

Fixes dotnet/runtime#128136